### PR TITLE
Support for "-f -"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Currently it indexes all functions, both public and private.
 ## Usage
 
     $ bin/javascript-ctags -?
-    javascript-ctags [-?] [-t tagfile] [fileglob]
+    javascript-ctags [-?] [-t/-f tagfile] [fileglob]
     --help, -h, -?	 show this
-    --tagfile, -t	 The generated tagfile (default tags)
+    --tagfile, -t, -f	 The generated tagfile (default tags), use - for STDOUT
     fileglob	 A glob pattern (supports **/*.js), (default *.js)
 
 

--- a/lib/javascript_ctags.js
+++ b/lib/javascript_ctags.js
@@ -27,8 +27,15 @@ function parse(files) {
 }
 
 function writeFile(filename, tags) {
-  fs.writeFileSync(filename, tags.join('\n'));
+  var content = tags.join("\n");
+  if(filename == "-") {
+    console.log(content);
+  } else {
+    fs.writeFileSync(filename, contents);
+  }
 }
+
+
 
 module.exports = parseAndGenerate;
 module.exports.files = files;

--- a/lib/javascript_ctags.js
+++ b/lib/javascript_ctags.js
@@ -27,9 +27,9 @@ function parse(files) {
 }
 
 function writeFile(filename, tags) {
-  var content = tags.join("\n");
+  var contents = tags.join("\n");
   if(filename == "-") {
-    console.log(content);
+    console.log(contents);
   } else {
     fs.writeFileSync(filename, contents);
   }
@@ -39,3 +39,4 @@ function writeFile(filename, tags) {
 
 module.exports = parseAndGenerate;
 module.exports.files = files;
+module.exports.writeFile = writeFile;

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,19 +18,20 @@ function parseArgs(args) {
   };
   var shortcuts = {
       t: '--tagfile',
+      f: '--tagfile',
       h: '--help',
       '?': '--help'
   };
 
   var options = nopt(longOptions, shortcuts, args);
   var rest = options.argv.remain;
-  options.pattern = rest.length > 0 ? rest[0] : '*.js';
+  options.pattern = rest.length > 0 ? rest[0] : './*.js';
   if (!options.tagfile) options.tagfile = 'tags';
   return options;
 }
 
 function usage() {
-  console.log('javascript-ctags [-?] [-t tagfile] [fileglob]');
+  console.log('javascript-ctags [-?] [-t or -f tagfile] [fileglob]');
   console.log('--help, -h, -?\t show this');
   console.log('--tagfile, -t\t The generated tagfile (default tags)');
   console.log('  fileglob\t A glob pattern (supports **/*.js), (default *.js)');

--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,7 @@ function parseArgs(args) {
 function usage() {
   console.log('javascript-ctags [-?] [-t or -f tagfile] [fileglob]');
   console.log('--help, -h, -?\t show this');
-  console.log('--tagfile, -t\t The generated tagfile (default tags)');
+  console.log('--tagfile, -t, -f\t The generated tagfile (default tags), use - for STDOUT');
   console.log('  fileglob\t A glob pattern (supports **/*.js), (default *.js)');
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,7 +25,7 @@ function parseArgs(args) {
 
   var options = nopt(longOptions, shortcuts, args);
   var rest = options.argv.remain;
-  options.pattern = rest.length > 0 ? rest[0] : './*.js';
+  options.pattern = rest.length > 0 ? rest[0] : '*.js';
   if (!options.tagfile) options.tagfile = 'tags';
   return options;
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "mocha": "~1.7.0",
-    "chai": "~1.3.0"
+    "chai": "~1.3.0",
+    "sinon": "~1.7"
   },
   "bin": { "javascript-ctags": "./bin/javascript-ctags" }
 }

--- a/test/javascript_ctags_spec.js
+++ b/test/javascript_ctags_spec.js
@@ -1,7 +1,9 @@
 "use strict";
 
 require('mocha');
+var sinon = require('sinon');
 var expect = require('chai').expect;
+var fs = require('fs');
 
 var javascriptCtags = require('../lib/javascript_ctags');
 
@@ -11,6 +13,34 @@ describe('main', function() {
     it('returns 5 nested files for fixtures/**/*.js', function() {
       var files = javascriptCtags.files(__dirname + '/fixtures/**/*.js', {debug: true});
       expect(files).to.have.length(5);
+    });
+  });
+
+  describe("#writeFile", function(){
+    var consoleSpy,
+        fsSpy,
+        tags = [];
+
+    beforeEach(function() {
+      consoleSpy = sinon.spy(console, 'log');
+      fsSpy = sinon.spy(fs, 'writeFileSync');
+    });
+
+    afterEach(function() {
+      console.log.restore();
+      fs.writeFileSync.restore();
+    });
+
+    it("writes contents to console if filename is -", function(){
+      javascriptCtags.writeFile("-", tags);
+      expect(consoleSpy.called).to.equal(true);
+      expect(fsSpy.called).to.equal(false);
+    });
+
+    it("writes contents to given file", function(){
+      javascriptCtags.writeFile("tags", tags);
+      expect(fsSpy.called).to.equal(true);
+      expect(consoleSpy.called).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Hi! 

First of all - thanks for creating this project - since `jsctags/doctorjs` has been abandoned I was looking for something like that, especially that excuberant-ctag's Javascript support isn't getting any better.

Now, for the pull request itself:

All ctags compatible tools I've used so far (or [wrote myself](https://github.com/lukaszkorecki/coffeetags)) need to support `-` as a tags file option which by convention means "print to stdout".

That makes `javascript-ctags` work with such tools as [tagbar plugin] for Vim (and similar plugins/tools for other editors).

Here's a screenshot: 
![tagbar + javascript-ctags](https://dl.dropboxusercontent.com/u/29110/screens/javascript-ctags.png)

To make this work with vim a bit of configuration is needed, stored in `~/.vim/ftplugin/javascript/tagbar-javascript.vim`:

``` viml

let g:tagbar_type_javascript = {
      \ 'ctagsbin' : 'javascript-ctags',
      \ 'ctagstype' : 'javascript',
      \ 'sro' : '.',
      \ 'kinds' : [
        \ 'f:functions:1'
      \ ],
      \'kind2scope ' : {  'f' : 'function' },
      \'scope2kind' : {  'function' : 'f' }
    \}
```

I believe that this also makes `javascript-ctags` work with Sublime Text's ctags plugin as well, although I don't use it myself so I haven't tested it either ;-)
